### PR TITLE
Run yard:audit before yard:coverage

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 # The default task
 
 desc 'Run the same tasks that the CI build will run'
-task default: %w[spec rubocop yard yard:coverage yard:audit bundle:audit build]
+task default: %w[spec rubocop yard yard:audit yard:coverage bundle:audit build]
 
 # Bundler Audit
 


### PR DESCRIPTION
The build was failing because of incomplete yard coverage (yard:coverage) before the list of things not covered was output (yard:audit).

This PR reverses that so that you know what YARD docs are missing.