### PR TITLE
For ActiveConcern, use "module ClassMethods" instead of "class_methods"

### DIFF
--- a/lib/active_model_persistence/indexable.rb
+++ b/lib/active_model_persistence/indexable.rb
@@ -56,7 +56,10 @@ module ActiveModelPersistence
     include ActiveModel::Attributes
     include ActiveModelPersistence::PrimaryKey
 
-    class_methods do
+    # When this module is included in another class, ActiveSupport::Concern will
+    # make these class methods on that class.
+    #
+    module ClassMethods
       # Returns a hash of indexes for the model keyed by name
       #
       # @example
@@ -147,6 +150,8 @@ module ActiveModelPersistence
       private
 
       # Defines the default options for a new ActiveModelPersistence::Index
+      #
+      # @return [Hash] the default options
       #
       # @api private
       #

--- a/lib/active_model_persistence/persistence.rb
+++ b/lib/active_model_persistence/persistence.rb
@@ -53,7 +53,10 @@ module ActiveModelPersistence
     include ActiveModelPersistence::PrimaryKey
     include ActiveModelPersistence::PrimaryKeyIndex
 
-    class_methods do
+    # When this module is included in another class, ActiveSupport::Concern will
+    # make these class methods on that class.
+    #
+    module ClassMethods
       # Creates a new model object in to the object store
       #
       # Create a new model object passing `attributes` and `block` to `.new` and then calls `#save`.
@@ -128,7 +131,7 @@ module ActiveModelPersistence
         object_array.size
       end
 
-      alias_method(:size, :count)
+      alias size count
 
       # Removes all model objects from the object store
       #

--- a/lib/active_model_persistence/primary_key.rb
+++ b/lib/active_model_persistence/primary_key.rb
@@ -38,7 +38,10 @@ module ActiveModelPersistence
     include ActiveModel::Model
     include ActiveModel::Attributes
 
-    class_methods do
+    # When this module is included in another class, ActiveSupport::Concern will
+    # make these class methods on that class.
+    #
+    module ClassMethods
       # Identifies the attribute that the `primary_key` accessor maps to
       #
       # The primary key is 'id' by default.

--- a/lib/active_model_persistence/primary_key_index.rb
+++ b/lib/active_model_persistence/primary_key_index.rb
@@ -16,7 +16,10 @@ module ActiveModelPersistence
     include ActiveModelPersistence::PrimaryKey
     include ActiveModelPersistence::Indexable
 
-    class_methods do
+    # When this module is included in another class, ActiveSupport::Concern will
+    # make these class methods on that class.
+    #
+    module ClassMethods
       # Finds an object in the :primary_key index whose primary matches the given value
       #
       # @example
@@ -37,9 +40,9 @@ module ActiveModelPersistence
         find_by_primary_key(primary_key_value).first
       end
 
-      private
-
       # Create the primary key index
+      #
+      # @return [void]
       #
       # @api private
       #
@@ -49,6 +52,12 @@ module ActiveModelPersistence
     end
 
     included do
+      # Returns the primary key index
+      #
+      # @return [ActiveModelPersistence::Index]
+      #
+      # @api private
+      #
       def primary_key_index
         self.class.indexes[:primary_key]
       end


### PR DESCRIPTION
In an ActiveConcern module (on that extends ActiveConcern), class methods can be specified either by passing a block to "class_methods" or in a nested "ClassMethods" module.  Both do exactly the same thing.

I have noticed that VS Code outline view, Rubocop, and YARD all seem to ignore the code in the "class_methods" block. It is more convenient when using these tools to use the nested "ClassMethods" module.