### PR TITLE
Fix spelling of UniqueConstraintError

### DIFF
--- a/lib/active_model_persistence/persistence.rb
+++ b/lib/active_model_persistence/persistence.rb
@@ -435,7 +435,7 @@ module ActiveModelPersistence
       #
       def _create
         return false unless primary_key?
-        raise UniqueContraintError if primary_key_index.include?(primary_key)
+        raise UniqueConstraintError if primary_key_index.include?(primary_key)
 
         self.class.object_array << self
 

--- a/spec/active_model_persistence/persistence_spec.rb
+++ b/spec/active_model_persistence/persistence_spec.rb
@@ -186,6 +186,19 @@ RSpec.describe ActiveModelPersistence::Persistence do
           expect(model_class.find('3')).to eq(subject[2])
         end
       end
+
+      context 'when trying to create two objects with the same primary_key' do
+        let(:attributes) do
+          [
+            { short_id: '1', name: 'foo' },
+            { short_id: '1', name: 'bar' }
+          ]
+        end
+
+        it 'should raise a UniqueConstraintError' do
+          expect(error_raised).to be_a(ActiveModelPersistence::UniqueConstraintError)
+        end
+      end
     end
 
     describe '#save' do


### PR DESCRIPTION
This PR fixes a misspelling of `UniqueConstraintError`.  It also adds a test for unique constraints which this typo points out was missing.