### PR TITLE
Improve the ObjectNotValidError message

### DIFF
--- a/lib/active_model_persistence.rb
+++ b/lib/active_model_persistence.rb
@@ -2,6 +2,7 @@
 
 require 'active_support'
 require 'active_model'
+require 'pp'
 
 # A set of mixins to add to ActiveModel classes to support persistence
 #
@@ -18,7 +19,48 @@ module ActiveModelPersistence
   class UniqueConstraintError < ModelError; end
 
   # Raised when trying to save an invalid object
-  class ObjectNotValidError < ModelError; end
+  # @api public
+  class ObjectNotValidError < ModelError
+    # Create a new ObjectNotValidError constructing a message from the invalid object
+    #
+    # @example
+    #   class Person
+    #     include ActiveModelPersistence::Persistence
+    #     attribute :id, :integer
+    #     validates :id, presence: true
+    #     attribute :name, :integer
+    #     validates :name, presence: true
+    #     attribute :age, :integer
+    #     validates :age, numericality: { greater_than: 13, less_than: 125 }, allow_nil: true
+    #   end
+    #   begin
+    #     Person.create!(id: 1)
+    #   rescue ObjectNotValidError => e
+    #     puts e.message
+    #   end
+    #
+    # @param invalid_object [Object] the invalid object being reported
+    #
+    def initialize(invalid_object)
+      super(error_message(invalid_object))
+    end
+
+    private
+
+    # Create the exception message
+    # @return [String] the exception message
+    # @api private
+    def error_message(invalid_object)
+      <<~ERROR_MESSAGE
+        #{invalid_object.class} object is not valid
+
+        Errors:
+        #{invalid_object.errors.full_messages.pretty_inspect}
+        Attributes:
+        #{invalid_object.attributes.pretty_inspect}
+      ERROR_MESSAGE
+    end
+  end
 
   # Raised when trying to save! or update! an object that has already been destroyed
   class ObjectDestroyedError < ModelError; end

--- a/lib/active_model_persistence/persistence.rb
+++ b/lib/active_model_persistence/persistence.rb
@@ -324,7 +324,7 @@ module ActiveModelPersistence
       #
       def save!(**_options, &block)
         raise ObjectDestroyedError if destroyed?
-        raise ObjectNotValidError unless valid?
+        raise ObjectNotValidError, self unless valid?
 
         new_record? ? _create(&block) : _update(&block)
         update_indexes

--- a/spec/active_model_persistence/persistence_spec.rb
+++ b/spec/active_model_persistence/persistence_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe ActiveModelPersistence::Persistence do
   context 'when included in a model' do
     let(:model_class) do
       Class.new do
+        def self.name
+          'ModelClass'
+        end
+
         include ActiveModelPersistence::Persistence
 
         attribute :short_id, :string


### PR DESCRIPTION
Improve the ObjectNotValidError message so that it lists the errors and the attribute values:

```text
Person object is not valid

Errors:
["Name can't be blank"]

Attributes:
{"id"=>1, "name"=>nil, "age"=>nil}
```