### PR TITLE
Add Persistence.empty?

### DIFF
--- a/lib/active_model_persistence/persistence.rb
+++ b/lib/active_model_persistence/persistence.rb
@@ -179,6 +179,21 @@ module ActiveModelPersistence
 
       alias size count
 
+      # Returns true if there are no model objects saved in the object store
+      #
+      # @example
+      #   array_of_attributes = [
+      #   ]
+      #   ModelExample.create(array_of_attributes)
+      #   ModelExample.size #=> 0
+      #   ModelExample.empty? #=> true
+      #
+      # @return [Integer] the number of model objects in the object store
+      #
+      def empty?
+        object_array.size.zero?
+      end
+
       # Removes all model objects from the object store
       #
       # Each saved model object's `#destroy` method is called.

--- a/spec/active_model_persistence/persistence_spec.rb
+++ b/spec/active_model_persistence/persistence_spec.rb
@@ -387,6 +387,7 @@ RSpec.describe ActiveModelPersistence::Persistence do
 
         it 'should have three object in the object store' do
           expect(model_class.size).to eq(3)
+          expect(model_class.empty?).to eq(false)
         end
 
         context 'after calling .destroy_all' do
@@ -396,6 +397,7 @@ RSpec.describe ActiveModelPersistence::Persistence do
 
           it 'should remove all objects from the obejct store' do
             expect(model_class.size).to be_zero
+            expect(model_class.empty?).to eq(true)
           end
         end
       end


### PR DESCRIPTION
Add Persistence.empty? so you can call `ModelClass.empty?` to determine if there are objects of the `ModelClass` type in the object store.

This avoids calling `ModelClass.size.zero?` and triggering Rubocop offenses.